### PR TITLE
Add a KDED module and tray icon to control whether showing keyboard is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ include(FeatureSummary)
 find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
     Core
     Gui
+    DBus
     Widgets
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(steam-qt-keyboard-plugin)
 
-set(QT_MIN_VERSION "5.11.0")
-set(KF5_MIN_VERSION "5.58.0")
+set(QT_MIN_VERSION "5.15.0")
+set(KF5_MIN_VERSION "5.88.0")
 
 find_package(ECM ${KF5_MIN_VERSION} REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
@@ -11,18 +11,22 @@ set(QML_IMPORT_PATH "${QML_DIRS}" CACHE STRING "Qt Creator 4.1 extra qml import 
 
 include(KDEInstallDirs)
 include(KDECMakeSettings)
-include(KDEFrameworkCompilerSettings NO_POLICY_SCOPE)
+include(KDECompilerSettings NO_POLICY_SCOPE)
 include(FeatureSummary)
 
 find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
     Core
     Gui
+    Widgets
 )
+
+find_package(KF5 ${KF5_MIN_VERSION} REQUIRED COMPONENTS CoreAddons DBusAddons Config I18n)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTK3 gtk+-3.0 IMPORTED_TARGET)
 
 add_subdirectory(src)
+add_subdirectory(kded)
 
 if (TARGET PkgConfig::GTK3)
     add_subdirectory(gtk)

--- a/gtk/steam-imcontext-gtk.c
+++ b/gtk/steam-imcontext-gtk.c
@@ -186,5 +186,15 @@ static void steam_im_context_enabled_changed(GDBusProxy* proxy, const gchar* sen
         return;
     }
 
-    STEAM_IM_CONTEXT(data)->enabled = g_variant_get_boolean(g_variant_get_child_value(parameters, 0));
+    SteamIMContext *context = STEAM_IM_CONTEXT(data);
+    context->enabled = g_variant_get_boolean(g_variant_get_child_value(parameters, 0));
+
+    if (context->enabled == gtk_false()) {
+        gchar* argv[4];
+        argv[0] = context->steamExecutable;
+        argv[1] = (gchar*)"-if-running";
+        argv[2] = (gchar*)"steam://close/keyboard";
+        argv[3] = NULL;
+        g_spawn_async(NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL);
+    }
 }

--- a/gtk/steam-imcontext-gtk.h
+++ b/gtk/steam-imcontext-gtk.h
@@ -32,6 +32,8 @@ typedef struct _SteamIMContextClass SteamIMContextClass;
 struct _SteamIMContext {
     GtkIMContext parent;
     gchar* steamExecutable;
+    GDBusProxy *keyboardService;
+    gboolean enabled;
 };
 
 struct _SteamIMContextClass {

--- a/kded/CMakeLists.txt
+++ b/kded/CMakeLists.txt
@@ -1,0 +1,14 @@
+
+kcoreaddons_add_plugin(steamkeyboard SOURCES
+    keyboardmodule.cpp
+    keyboardmodule.h
+    INSTALL_NAMESPACE "kf5/kded"
+)
+
+target_link_libraries(steamkeyboard
+    KF5::CoreAddons
+    KF5::DBusAddons
+    KF5::ConfigCore
+    KF5::I18n
+    Qt5::Widgets
+)

--- a/kded/keyboardmodule.cpp
+++ b/kded/keyboardmodule.cpp
@@ -1,0 +1,51 @@
+#include "keyboardmodule.h"
+
+#include <KConfigGroup>
+#include <KPluginFactory>
+#include <KLocalizedString>
+
+K_PLUGIN_CLASS_WITH_JSON(KeyboardModule, "keyboardmodule.json")
+
+static const QString KeyboardEnabledIcon = QStringLiteral("input-keyboard-virtual-on");
+static const QString KeyboardDisabledIcon = QStringLiteral("input-keyboard-virtual-off");
+
+KeyboardModule::KeyboardModule(QObject *parent, const QVariantList &)
+    : KDEDModule(parent)
+{
+    m_config = KSharedConfig::openConfig();
+    m_enabled = m_config->group(QStringLiteral("SteamKeyboard")).readEntry<bool>("enabled", true);
+    m_trayIcon = std::make_unique<QSystemTrayIcon>();
+    m_trayIcon->setIcon(QIcon::fromTheme(m_enabled ? KeyboardEnabledIcon : KeyboardDisabledIcon));
+    m_trayIcon->setToolTip(i18n("Toggle Steam Virtual Keyboard"));
+    connect(m_trayIcon.get(), &QSystemTrayIcon::activated, this, &KeyboardModule::onTrayIconActivated);
+    m_trayIcon->show();
+}
+
+bool KeyboardModule::isEnabled() const
+{
+    return m_enabled;
+}
+
+void KeyboardModule::setEnabled(bool enabled)
+{
+    if (enabled == m_enabled) {
+        return;
+    }
+
+    m_enabled = enabled;
+    m_config->group(QStringLiteral("SteamKeyboard")).writeEntry("enabled", m_enabled);
+    Q_EMIT enabledChanged(m_enabled);
+}
+
+void KeyboardModule::onTrayIconActivated(QSystemTrayIcon::ActivationReason reason)
+{
+    if (reason != QSystemTrayIcon::Trigger) {
+        return;
+    }
+
+    setEnabled(!m_enabled);
+    m_trayIcon->setIcon(QIcon::fromTheme(m_enabled ? KeyboardEnabledIcon : KeyboardDisabledIcon));
+}
+
+#include "keyboardmodule.moc"
+

--- a/kded/keyboardmodule.h
+++ b/kded/keyboardmodule.h
@@ -1,0 +1,27 @@
+
+#pragma once
+
+#include <memory>
+#include <QSystemTrayIcon>
+#include <KDEDModule>
+#include <KSharedConfig>
+
+class KeyboardModule : public KDEDModule
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "com.valvesoftware.keyboard")
+
+public:
+    explicit KeyboardModule(QObject *parent, const QVariantList &);
+
+    Q_SCRIPTABLE bool isEnabled() const;
+    Q_SCRIPTABLE void setEnabled(bool enabled);
+    Q_SCRIPTABLE Q_SIGNAL void enabledChanged(bool enabled);
+
+private:
+    void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
+
+    bool m_enabled = true;
+    KSharedConfig::Ptr m_config;
+    std::unique_ptr<QSystemTrayIcon> m_trayIcon;
+};

--- a/kded/keyboardmodule.json
+++ b/kded/keyboardmodule.json
@@ -1,0 +1,10 @@
+{
+    "KPlugin": {
+        "Description": "Control whether the steam virtual keyboard is automatically shown or not.",
+        "Icon": "input-keyboard-virtual",
+        "Name": "Steam Virtual Keyboard"
+    },
+    "X-KDE-Kded-autoload": true,
+    "X-KDE-Kded-load-on-demand": false,
+    "X-KDE-Kded-phase": 2
+}

--- a/kded/keyboardmodule.json
+++ b/kded/keyboardmodule.json
@@ -6,5 +6,6 @@
     },
     "X-KDE-Kded-autoload": true,
     "X-KDE-Kded-load-on-demand": false,
-    "X-KDE-Kded-phase": 2
+    "X-KDE-Kded-phase": 2,
+    "X-KDE-OnlyShowOnQtPlatforms": ["xcb"]
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(steam-qt-keyboard-plugin MODULE ${keyboard_plugin_SRCS})
 
 target_link_libraries(steam-qt-keyboard-plugin
     Qt5::GuiPrivate # for qpa
+    Qt5::DBus
 )
 
 install(TARGETS steam-qt-keyboard-plugin LIBRARY DESTINATION ${KDE_INSTALL_QTPLUGINDIR}/platforminputcontexts)

--- a/src/steaminputcontext.cpp
+++ b/src/steaminputcontext.cpp
@@ -110,6 +110,9 @@ void SteamInputContext::onEnabledChanged(bool enabled)
     m_enabled = enabled;
 
     if (!m_enabled) {
-        hideInputPanel();
+        // This should ideally just call hideInputPanel() but putting this into
+        // hideInputPanel causes issues due to focus loops, so instead only
+        // explicitly close when we know the keyboard should be disabled.
+        QProcess::startDetached(m_steamExecutable, {QStringLiteral("-ifrunning"), QStringLiteral("steam://close/keyboard")});
     }
 }

--- a/src/steaminputcontext.h
+++ b/src/steaminputcontext.h
@@ -33,7 +33,10 @@ public:
     void hideInputPanel() override;
     bool isInputPanelVisible() const override;
 
+    Q_SLOT void onEnabledChanged(bool enabled);
+
 private:
     bool m_visible = false;
+    bool m_enabled = true;
     QString m_steamExecutable;
 };


### PR DESCRIPTION
This adds a KDED module that exposes a simple "enabled" property that the IM plugins can connect to to check if the keyboard should be shown when requested. It also adds a simple systray icon to toggle it.

From my testing this all works, the only thing left is to not have the systray icon visible when using Wayland.